### PR TITLE
fix #6  missing include <cstdint> in pcsc-mock.hpp

### DIFF
--- a/include/pcsc-mock/pcsc-mock.hpp
+++ b/include/pcsc-mock/pcsc-mock.hpp
@@ -27,6 +27,7 @@
 #include <map>
 #include <vector>
 #include <stdexcept>
+#include <stdint.h>
 
 #ifdef _WIN32
 using MOCK_LONG = int32_t;


### PR DESCRIPTION
It is holding back development (https://github.com/web-eid/libpcsc-mock/issues/6#issuecomment-1536142252).